### PR TITLE
added style for yaml dump

### DIFF
--- a/src/store/cff.ts
+++ b/src/store/cff.ts
@@ -38,7 +38,12 @@ const cff = ref<CFF>({
 export function useCFF () {
     return {
         abstract: computed(() => cff.value.abstract),
-        asYAML: computed(() => yaml.dump(cff.value)),
+        asYAML: computed(() => yaml.dump(cff.value, {
+            indent: 4,
+            lineWidth: 70,
+            quotingType: '"',
+            sortKeys: true
+        })),
         cff: computed(() => cff.value),
         commit: computed(() => cff.value.commit),
         date_released: computed(() => cff.value.date_released),


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: #84

## Describe the changes made in this pull request

This PR adds configuration to dumping the yaml. It works with regard to line length, indent and sort keys, but not quoting. Odd, because this same library used with the same settings here https://jspaaks.github.io/vue-sandbox/ does work.

If I try with:
```javascript 
asYAML: computed(() => yaml.dump({ a: 4, c: ['string: with quotes', 2, 3], b: '567890 23456789 567890123456789012345678901234567890' }, {
    indent: 4,
    lineWidth: 20,
    quotingType: '"',
    sortKeys: true
})),
```

I see: 
```yaml
a: 4
b: >-
    567890 23456789
    567890123456789012345678901234567890
c:
    - 'string: with quotes'
    - 2
    - 3
```

## Instructions to review the pull request

```shell
npm run dev
# look in browser
```