### PR TITLE
Deep filter empty keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5037,6 +5037,14 @@
         "regexp.prototype.flags": "^1.2.0"
       }
     },
+    "deep-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-filter/-/deep-filter-1.0.2.tgz",
+      "integrity": "sha1-z3JBNo8ndx3xTZ6CqmEC+inUBlY=",
+      "requires": {
+        "is-plain-object": "^2.0.1"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -8076,7 +8084,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -8178,8 +8185,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "@quasar/extras": "^1.0.0",
         "core-js": "^3.6.5",
+        "deep-filter": "^1.0.2",
         "js-yaml": "^3.14.1",
         "kebabcase-keys": "^1.0.0",
         "quasar": "^2.0.0"

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -19,11 +19,14 @@
 <script lang="ts">
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { defineComponent, computed } from 'vue'
 import { useCff } from 'src/store/cff'
 import yaml from 'js-yaml'
 import { CffType } from 'src/types'
 import kebabcaseKeys from 'kebabcase-keys'
+import deepfilter from 'deep-filter'
 
 export default defineComponent({
     name: 'Preview',
@@ -49,6 +52,18 @@ export default defineComponent({
         const copyToClipboard = async () => {
             await navigator.clipboard.writeText(makeCffstr())
         }
+        const notEmpty = (value: unknown, prop: unknown, subject: unknown) => {
+            // based on https://www.npmjs.com/package/deep-filter example
+            if (Array.isArray(value)) {
+                return value.length > 0
+            } else if (typeof value === 'object' && value !== null) {
+                return Object.keys(value).length > 0
+            } else if (typeof value === 'string') {
+                return value.length > 0
+            } else {
+                return value != null
+            }
+        }
         const makeCffstr = () => {
             const cff = {
                 abstract: abstract.value,
@@ -67,7 +82,10 @@ export default defineComponent({
                 url: url.value,
                 version: version.value
             } as CffType
-            return yaml.dump(kebabcaseKeys(cff), { indent: 2, sortKeys: true })
+            const filtered = deepfilter(cff, notEmpty)
+            const kebabed = kebabcaseKeys(filtered)
+
+            return yaml.dump(kebabed, { indent: 2, sortKeys: true })
         }
 
         return {

--- a/src/deep-filter.d.ts
+++ b/src/deep-filter.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'deep-filter' {
+    const deepfilter: any
+    export default deepfilter
+}


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: #none

## Describe the changes made in this pull request

In this PR, I used the https://www.npmjs.com/package/deep-filter library to filter out keys whose values are empty, such as `''`, `{}`, `[]`, or `null`. I used the example from Usage, with some changes.

## Instructions to review the pull request

- `npm run dev`
- localhost:8080
- should have only `cff-version` and `type` until you start filling in other keys; keys should be removed if you make them empty strings
