### PR TITLE
fixes warning about js-yaml not having a default export

### DIFF
--- a/src/store/cffstr.ts
+++ b/src/store/cffstr.ts
@@ -4,7 +4,7 @@
 
 import { computed } from 'vue'
 import { useCff } from 'src/store/cff'
-import yaml from 'js-yaml'
+import * as yaml from 'js-yaml'
 import { CffType } from 'src/types'
 import kebabcaseKeys from 'kebabcase-keys'
 import deepfilter from 'deep-filter'


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: #nope

## Describe the changes made in this pull request
My editor warned the js-yaml doesnt have a default export hence
```typescript
import yaml from 'js-yaml'
```

was problematic.

This PR changes that to 
```typescript
import * as yaml from 'js-yaml'
```

## Instructions to review the pull request

- look at file diff
- see if the Preview still works
