### PR TITLE
initialized keywords with some empty strings

### DIFF
--- a/src/store/cff.ts
+++ b/src/store/cff.ts
@@ -8,7 +8,11 @@ const cff = ref({
     commit: '',
     dateReleased: '',
     identifiers: [],
-    keywords: [],
+    keywords: [
+        '',
+        '',
+        ''
+    ],
     license: '',
     message: '',
     repository: '',


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #230

## Describe the changes made in this pull request

This PR initializes keywords with a placeholder array of empty strings to make filling in data a bit easier and to avoid people interpreting the keywords field as a comma-separated string (#230).

## Instructions to review the pull request
