### PR TITLE
Use filter on license dropdown; refs #289

### DIFF
--- a/src/components/ScreenLicense.vue
+++ b/src/components/ScreenLicense.vue
@@ -18,9 +18,11 @@
                 label="license"
                 outlined
                 standout
+                use-input
                 v-bind:model-value="license"
-                v-bind:options="licenses"
+                v-bind:options="options"
                 v-bind:rules="[ validateLicense ]"
+                v-on:filter="filterFn"
                 v-on:update:model-value="setLicense"
             />
         </div>
@@ -32,7 +34,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { makeOptionalFieldValidator } from 'src/validator'
 import { useCff } from '../store/cff'
 import schema from '../schemas/1.2.0/schema.json'
@@ -47,11 +49,28 @@ export default defineComponent({
     },
     setup () {
         const cff = useCff()
+        const licenses = schema.definitions['license-enum'].enum
+        const options = ref(licenses)
+
         return {
             license: cff.license,
-            licenses: schema.definitions['license-enum'].enum,
+            licenses: licenses,
+            options,
             setLicense: cff.setLicense,
-            validateLicense: makeOptionalFieldValidator('/definitions/license-enum')
+            validateLicense: makeOptionalFieldValidator('/definitions/license-enum'),
+            filterFn (val: string, update: (a:unknown) => void) {
+                if (val === '') {
+                    update(() => {
+                        options.value = licenses
+                    })
+                    return
+                }
+
+                update(() => {
+                    const needle = val.toLowerCase()
+                    options.value = licenses.filter(v => v.toLowerCase().indexOf(needle) > -1)
+                })
+            }
         }
     }
 })


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs: #289


## Describe the changes made in this pull request

Enables a textbox on the license dropdown that filters the licenses.
I followed https://quasar.dev/vue-components/select#options-list-display-mode, but I had to include types, so that may be wrong.

## Instructions to review the pull request


```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cffinit .
git checkout 289-filtering-license-dropdown
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
