### PR TITLE
Finish button remains hidden until the user enters advanced mode

### DIFF
--- a/src/components/StepperActions.vue
+++ b/src/components/StepperActions.vue
@@ -18,6 +18,7 @@
             flat
             label="Finish"
             no-caps
+            v-bind:class="!showAdvanced ? 'hidden' : ''"
             v-bind:to="showAdvanced === true ? '/finish-advanced' : '/finish-minimum'"
         />
         <q-btn


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #382


## Describe the changes made in this pull request

Reuses `showAdvanced` to decide whether to hide the `finish` button or not.
This way:
- it is hidden before the user fixes the errors on Start and Authors - because he is soft-blocked from the advanced part;
- when he enters advanced, the `finish` button appears on all screens keeping consistency.
<!-- include screenshots if that helps the review -->


## Instructions to review the pull request


```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cffinit .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
