### PR TITLE
Don't sort YAML output and order cff object to reflect the form order

### DIFF
--- a/src/store/cffstr.ts
+++ b/src/store/cffstr.ts
@@ -35,22 +35,22 @@ export function useCffstr () {
 
     const makeJavascriptObject = () => {
         const cff = {
-            abstract: abstract.value,
-            authors: authors.value,
-            commit: commit.value,
             cffVersion: cffVersion.value,
-            dateReleased: dateReleased.value,
-            identifiers: identifiers.value,
-            keywords: keywords.value,
-            license: license.value,
+            title: title.value,
             message: message.value,
+            type: type.value,
+            authors: authors.value,
+            identifiers: identifiers.value,
+            repositoryCode: repositoryCode.value,
+            url: url.value,
             repository: repository.value,
             repositoryArtifact: repositoryArtifact.value,
-            repositoryCode: repositoryCode.value,
-            title: title.value,
-            type: type.value,
-            url: url.value,
-            version: version.value
+            abstract: abstract.value,
+            keywords: keywords.value,
+            license: license.value,
+            commit: commit.value,
+            version: version.value,
+            dateReleased: dateReleased.value
         } as CffType
         const filtered = deepfilter(cff, notEmpty)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -59,7 +59,7 @@ export function useCffstr () {
 
     const makeCffstr = () => {
         const kebabed = makeJavascriptObject()
-        const yamlString = yaml.dump(kebabed, { indent: 2, sortKeys: true, lineWidth: 53 })
+        const yamlString = yaml.dump(kebabed, { indent: 2, lineWidth: 53 })
         const generatedBy = '# This CITATION.cff file was generated with cffinit.\n# Visit https://bit.ly/cffinit to generate yours today!\n\n'
         return generatedBy + yamlString
     }

--- a/test/jest/__tests__/store/cffstr.jest.spec.ts
+++ b/test/jest/__tests__/store/cffstr.jest.spec.ts
@@ -12,7 +12,7 @@ describe('useCffstr', () => {
     })
     describe('initial content', () => {
         it('should only have fields with defaults', () => {
-            const expected = generatedBy + 'authors: []\ncff-version: 1.2.0\ntype: software\n'
+            const expected = generatedBy + 'cff-version: 1.2.0\ntype: software\nauthors: []\n'
             expect(cffstr.value).toEqual(expected)
         })
     })
@@ -23,7 +23,7 @@ describe('useCffstr', () => {
         })
 
         it('should have title', () => {
-            const expected = generatedBy + 'authors: []\ncff-version: 1.2.0\ntitle: sometitle\ntype: software\n'
+            const expected = generatedBy + 'cff-version: 1.2.0\ntitle: sometitle\ntype: software\nauthors: []\n'
             expect(cffstr.value).toEqual(expected)
         })
     })
@@ -34,7 +34,7 @@ describe('useCffstr', () => {
         })
 
         it('should have a keyword', () => {
-            const expected = generatedBy + 'authors: []\ncff-version: 1.2.0\nkeywords:\n  - keyword1\ntype: software\n'
+            const expected = generatedBy + 'cff-version: 1.2.0\ntype: software\nauthors: []\nkeywords:\n  - keyword1\n'
             expect(cffstr.value).toEqual(expected)
         })
     })
@@ -45,7 +45,7 @@ describe('useCffstr', () => {
         })
 
         it('should have a identifier', () => {
-            const expected = generatedBy + 'authors: []\ncff-version: 1.2.0\nidentifiers:\n  - type: doi\n    value: 10.5281/zenodo.5171937\ntype: software\n'
+            const expected = generatedBy + 'cff-version: 1.2.0\ntype: software\nauthors: []\nidentifiers:\n  - type: doi\n    value: 10.5281/zenodo.5171937\n'
             expect(cffstr.value).toEqual(expected)
         })
     })


### PR DESCRIPTION
# Pull request details

## List of related issues or pull requests

Refs:
- #404


## Describe the changes made in this pull request

Removed `sortKeys` and manually reordered `cff`.
I haven't been able to find a reference to guarantee that the order stays the same.
![image](https://user-images.githubusercontent.com/1068752/139711799-68284a98-fb1c-4ff4-99f4-9a9de3e3b4fa.png)

<!-- include screenshots if that helps the review -->


## Instructions to review the pull request


```shell
cd $(mktemp -d --tmpdir cffinit-pr.XXXXXX)
git clone https://github.com/citation-file-format/cffinit .
git checkout <this branch>
npm clean-install
npm run dev
# go to localhost:8080, see if the app works correctly
npm run lint
npm run test:unit:ci
```
